### PR TITLE
Spectra

### DIFF
--- a/.github/workflows/docs-examples.yml
+++ b/.github/workflows/docs-examples.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           set -xe
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install .
+          python -m pip install .[data]
           python -m pip install jupytext
 
       - name: Run the docs examples

--- a/crt1d/data/__init__.py
+++ b/crt1d/data/__init__.py
@@ -8,7 +8,7 @@ import numpy as np
 import xarray as xr
 
 from .. import DATA_BASE_DIR
-from ..spectra import edges_from_centers
+from ..spectra import _edges_from_centers
 from ..variables import _tup
 from .external import solar_sp2
 
@@ -146,7 +146,7 @@ def load_default_sp2(*, midpt=True):
         I_df = (SI_df0[:-1] + SI_df0[1:]) / 2 * dwl
 
     else:  # edges-from-centers method
-        wle = edges_from_centers(wl0)
+        wle = _edges_from_centers(wl0)
         dwl = np.diff(wle)
         wl = wl0  # for in-band irradiance (and original spectral irradiance)
 

--- a/crt1d/data/__init__.py
+++ b/crt1d/data/__init__.py
@@ -10,13 +10,11 @@ import xarray as xr
 from .. import DATA_BASE_DIR
 from ..spectra import _edges_from_centers
 from ..variables import _tup
-from .external import solar_sp2
+from ..variables import _wl_coord_dict
+from ._external import leaf_ps5
+from ._external import solar_sp2
 
 DATA_DIR_STR = DATA_BASE_DIR.as_posix()
-
-
-def _wl_coord_dict(wl, *, units="μm"):
-    return {"wl": (("wl"), wl, {"long_name": "Wavelength", "units": units})}
 
 
 def load_soil_fuentes2007(wl_um):
@@ -134,7 +132,7 @@ def load_default_sp2(*, midpt=True):
     fp = DATA_BASE_DIR / "SPCTRAL2_xls_default-spectrum.csv"
     wl0, SI_dr0, SI_df0 = np.loadtxt(fp, delimiter=",", skiprows=1, unpack=True)
 
-    # TODO: use `_interpret_dx_relative_spectrum` here and in `solar_sp2`?
+    # TODO: use `_interpret_dx_relative_spectrum` here and in `solar_sp2`? and ideal leaf?
     if midpt:
         wle = wl0
         dwl = np.diff(wle)
@@ -186,6 +184,14 @@ def load_default_sp2(*, midpt=True):
 def load_default(*, midpt=True):
     """Load default toc irradiance spectra, and leaf & soil optical props,
     used in :func:`~crt1d.cases.load_default_case`.
+
+    The defaults are given by:
+
+    * :func:`load_ideal_leaf`
+
+    * :func:`load_default_sp2`
+
+    * :func:`load_soil_fuentes2007`
     """
     # load individual datasets
     ds_l = load_ideal_leaf(midpt=midpt)

--- a/crt1d/data/__init__.py
+++ b/crt1d/data/__init__.py
@@ -134,6 +134,7 @@ def load_default_sp2(*, midpt=True):
     fp = DATA_BASE_DIR / "SPCTRAL2_xls_default-spectrum.csv"
     wl0, SI_dr0, SI_df0 = np.loadtxt(fp, delimiter=",", skiprows=1, unpack=True)
 
+    # TODO: use `_interpret_dx_relative_spectrum` here and in `solar_sp2`?
     if midpt:
         wle = wl0
         dwl = np.diff(wle)

--- a/crt1d/data/_external.py
+++ b/crt1d/data/_external.py
@@ -8,13 +8,57 @@ import xarray as xr
 
 from ..spectra import _interpret_dx_relative_spectrum
 from ..variables import _tup
+from ..variables import _wl_coord_dict
 
 
-def leaf_ps5():
-    """Run PROSPECT from Python package ``prosail`` to generate leaf spectra."""
+def leaf_ps5(n=1.2, cab=30.0, car=10.0, cbrown=1.0, ewt=0.015, lma=0.009):
+    """Run PROSPECT-5 from Python package ``prosail``
+    (source `on GitHub <https://github.com/jgomezdans/prosail>`_)
+    to generate leaf spectra.
+
+    Default values are the same as those on the
+    `online PROSPECT page <http://opticleaf.ipgp.fr/index.php?page=prospect>`_.
+
+    Parameters
+    ----------
+    n : float
+        Leaf structure parameter (number of effective layers of leaf?; dimensionless).
+        Typical range: [0.8, 3.0].
+    cab : float
+        Chlorophyll a+b concentration (μg cm-2).
+        Typical range: [0, 100].
+    car : float
+        Carotenoid concentration (μg cm-2).
+        Typical range: [0, 25].
+    cbrown : float
+        Brown pigment fraction/factor in [0, 1].
+    ewt : float
+        Equivalent leaf water thickness (cm).
+        Typical range: [0, 0.05].
+    lma : float
+        Leaf dry mass per unit area (g cm-2).
+        Typical range: [0, 0.02].
+
+    Notes
+    -----
+    Quoted typical ranges are based on the PROSPECT page and Python PROSAIL readme linked above.
+    """
     import prosail
 
-    raise NotImplementedError
+    wl_nm, r, t = prosail.run_prospect(n, cab, car, cbrown, ewt, lma, prospect_version="5")
+
+    wl = wl_nm / 1000  # nm -> um
+
+    attrs = {}
+    ds = xr.Dataset(
+        coords=_wl_coord_dict(wl),
+        data_vars={
+            "rl": _tup("leaf_r", r),
+            "tl": _tup("leaf_t", t),
+        },
+        attrs=attrs,
+    )
+    return ds
 
 
 def solar_sp2(

--- a/crt1d/data/_external.py
+++ b/crt1d/data/_external.py
@@ -11,7 +11,7 @@ from ..variables import _tup
 from ..variables import _wl_coord_dict
 
 
-def leaf_ps5(n=1.2, cab=30.0, car=10.0, cbrown=1.0, ewt=0.015, lma=0.009):
+def leaf_ps5(n=1.2, cab=30.0, car=10.0, cbr=1.0, ewt=0.015, lma=0.009):
     """Run PROSPECT-5 from Python package ``prosail``
     (source `on GitHub <https://github.com/jgomezdans/prosail>`_)
     to generate leaf spectra.
@@ -30,7 +30,7 @@ def leaf_ps5(n=1.2, cab=30.0, car=10.0, cbrown=1.0, ewt=0.015, lma=0.009):
     car : float
         Carotenoid concentration (μg cm-2).
         Typical range: [0, 25].
-    cbrown : float
+    cbr : float
         Brown pigment fraction/factor in [0, 1].
     ewt : float
         Equivalent leaf water thickness (cm).
@@ -39,13 +39,19 @@ def leaf_ps5(n=1.2, cab=30.0, car=10.0, cbrown=1.0, ewt=0.015, lma=0.009):
         Leaf dry mass per unit area (g cm-2).
         Typical range: [0, 0.02].
 
+    Returns
+    -------
+    xr.Dataset
+        Dataset of the leaf reflectance and transmittance spectra,
+        and PROSPECT input parameters as dimensionless variables.
+
     Notes
     -----
     Quoted typical ranges are based on the PROSPECT page and Python PROSAIL readme linked above.
     """
     import prosail
 
-    wl_nm, r, t = prosail.run_prospect(n, cab, car, cbrown, ewt, lma, prospect_version="5")
+    wl_nm, r, t = prosail.run_prospect(n, cab, car, cbr, ewt, lma, prospect_version="5")
 
     wl = wl_nm / 1000  # nm -> um
 
@@ -55,6 +61,12 @@ def leaf_ps5(n=1.2, cab=30.0, car=10.0, cbrown=1.0, ewt=0.015, lma=0.009):
         data_vars={
             "rl": _tup("leaf_r", r),
             "tl": _tup("leaf_t", t),
+            "n": ((), n, {"long_name": "Leaf structure parameter", "units": ""}),
+            "cab": ((), cab, {"long_name": "Chlorophyll a+b", "units": "μg cm-2"}),
+            "car": ((), car, {"long_name": "Carotenoid", "units": "μg cm-2"}),
+            "cbr": ((), cbr, {"long_name": "Brown pigment", "units": ""}),
+            "ewt": ((), ewt, {"long_name": "Equivalent leaf water thickness", "units": "cm"}),
+            "lma": ((), lma, {"long_name": "Leaf dry mass density", "units": "g cm-2"}),
         },
         attrs=attrs,
     )

--- a/crt1d/data/external.py
+++ b/crt1d/data/external.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 import xarray as xr
 
-from ..spectra import interpret_spectrum
+from ..spectra import _interpret_dx_relative_spectrum
 from ..variables import _tup
 
 

--- a/crt1d/spectra.py
+++ b/crt1d/spectra.py
@@ -3,8 +3,41 @@ Spectral manipulations.
 """
 import numpy as np
 import xarray as xr
+from scipy.constants import c
+from scipy.constants import h
+from scipy.constants import k as k_B
 from scipy.integrate import cumtrapz
+from scipy.integrate import quad
 from scipy.interpolate import InterpolatedUnivariateSpline
+
+
+def l_wl_planck(T_K, wl_um):
+    """Planck radiance.
+
+    Parameters
+    ----------
+    T_K : float, ndarray
+        Temperature (K).
+    wl_um : float, ndarray
+        Wavelength (μm).
+    """
+    wl = wl_um * 1e-6  # -> m
+    return (2 * h * c ** 2) / (wl ** 5 * (np.exp(h * c / (wl * k_B * T_K)) - 1))
+
+
+def l_wl_planck_integ(T_K, wla_um, wlb_um):
+    """Numerical integral of Planck radiance from `wla_um` to `wlb_um`.
+
+    Parameters
+    ----------
+    T_K : float, ndarray
+        Temperature (K).
+    wla_um : float
+        Integration lower bound.
+    wlb_um : float
+        Upper bound.
+    """
+    return quad(l_wl_planck, wla_um, wlb_um)[0]
 
 
 def smear_tuv_1(x, y, bin):
@@ -275,7 +308,7 @@ def plot_binned(x, y, xc, yc, dx):
     spectrum_ls = "r-" if x.size > 150 else "r.-"
     xbounds = (x[0], x[-1])
 
-    fig, ax = plt.subplots(figsize=(9, 5))
+    fig, ax = plt.subplots(figsize=(7, 4))
 
     ax.bar(xc, yc, width=dx, label="binned", align="center", alpha=0.7, edgecolor="blue")
 
@@ -284,10 +317,10 @@ def plot_binned(x, y, xc, yc, dx):
     if isinstance(x, xr.DataArray) and isinstance(y, xr.DataArray):
         unx = cf_units_to_tex(x.attrs["units"])
         lnx = x.attrs["long_name"]
-        xlabel = f"{lnx} ({unx})"
+        xlabel = f"{lnx} [{unx}]"
         uny = cf_units_to_tex(y.attrs["units"])
         lny = y.attrs["long_name"]
-        ylabel = f"{lny} ({uny})"
+        ylabel = f"{lny} [{uny}]"
         ax.set_xlabel(xlabel)
         ax.set_ylabel(ylabel)
 

--- a/crt1d/spectra.py
+++ b/crt1d/spectra.py
@@ -124,6 +124,9 @@ def smear_ds(ds, bins, *, xname="wl", xname_out=None, method="tuv", **method_kwa
 
     Parameters
     ----------
+    ds : xr.Dataset
+    bins : array_like
+        Bin edges for the smeared spectrum.
     xname_out : str, optional
         By default, same as `xname`.
     method : str

--- a/crt1d/spectra.py
+++ b/crt1d/spectra.py
@@ -514,7 +514,7 @@ def smear_si(ds, bins, *, xname_out="wl", **kwargs):
     return ds_new
 
 
-def edges_from_centers(x):
+def _edges_from_centers(x):
     """Estimate locations of the bin edges by extrapolating the grid spacing at the edges.
 
     .. warning::
@@ -545,7 +545,7 @@ def _interpret_dx_relative_spectrum(ydx, x, *, midpt=True):
     Summing these *y* values is equivalent to the midpoint Riemann sum of the original
     *y(x)/dx*.
 
-    With the edges-from-centers method (``midpt=False``; uses :func:`edges_from_centers`),
+    With the edges-from-centers method (``midpt=False``; uses :func:`_edges_from_centers`),
     the return arrays will be size *n*.
     Estimating the edges allows the original *y(x)/dx* values to be used to compute *y(x*).
 
@@ -562,7 +562,7 @@ def _interpret_dx_relative_spectrum(ydx, x, *, midpt=True):
         y = (ydx[:-1] + y[1:]) / 2 * dx
 
     else:  # edges-from-centers method
-        xe = edges_from_centers(x)  # n+1 values
+        xe = _edges_from_centers(x)  # n+1 values
         dx = np.diff(xe)
 
         x_y = x  # original grid

--- a/crt1d/variables.py
+++ b/crt1d/variables.py
@@ -8,6 +8,17 @@ class VmdEntry:  # TODO: base on NamedTuple or dataclass??
     """Variable metadata for one variable."""
 
     def __init__(self, name, params, param_defaults):
+        """
+        Parameters
+        ----------
+        name : str
+            Code variable name associated with the variable.
+            Used as the ``name`` for :class:`xarray.DataArray`\s.
+        params : dict
+            Parameters for this variable.
+        param_defaults : dict
+            Default parameters (to use if `params` is missing any of the needed).
+        """
         self.name = name
 
         # required (we want it to fail if not provided)
@@ -30,7 +41,9 @@ class VmdEntry:  # TODO: base on NamedTuple or dataclass??
             self.dims = ()
 
     def da_attrs(self):
-        """Contruct dict of attributes to use when creating xarray DataArray for this variable."""
+        """Return dict of attributes to use when creating an :class:`xarray.DataArray`
+        for this variable.
+        """
         attrs = {
             "long_name": self.long_name,
             "units": self.s_units,
@@ -45,7 +58,7 @@ class VmdEntry:  # TODO: base on NamedTuple or dataclass??
         return attrs
 
     def dv_tuple(self, data):
-        """Construct `xr.Dataset` ``data_vars`` tuple."""
+        """Construct an :class:`xarray.Dataset` ``data_vars`` tuple."""
         return (self.dims, data, self.da_attrs())
 
     def param_entry(self, optional=False) -> str:
@@ -60,11 +73,11 @@ class VmdEntry:  # TODO: base on NamedTuple or dataclass??
         """.strip()
 
     def list_table_entry(self, fields) -> str:
-        """Construct a MyST list-table entry.
+        """Construct a MyST list-table entry for the docs variable summary table.
 
         Parameters
         ----------
-        fields : list(str)
+        fields : list of str
             Parameters to include (in desired order).
         """
         lines = []
@@ -90,8 +103,8 @@ class VmdEntry:  # TODO: base on NamedTuple or dataclass??
 
         return "\n".join(lines).rstrip()
 
-    def details_sec(self, *, heading_level=3):
-        """Details section for docs."""
+    def details_sec(self, *, heading_level=3) -> str:
+        """Construct details section for docs variables page."""
         pre0 = "#" * heading_level
         header = f"{pre0} ``{self.name}``"
         l_units_long = (
@@ -141,12 +154,12 @@ class Vmd:
         """
         Parameters
         ----------
-        vmdes : list(VmdEntry)
+        vmdes : list of VmdEntry
         """
         self.variables = {vmde.name: vmde for vmde in vmdes}
 
     def intent(self, intent="in"):
-        """Filtered set of variables with intent=`intent`.
+        """Return filtered set of variables that have the specified `intent`.
 
         Parameters
         ----------
@@ -155,7 +168,7 @@ class Vmd:
         Returns
         -------
         dict
-            name: VmdEntry
+            ``name: VmdEntry``
         """
         if intent is None or intent == "all":
             return self.variables.copy()

--- a/crt1d/variables.py
+++ b/crt1d/variables.py
@@ -265,6 +265,10 @@ def _tup(name, data):
     return VMD[name].dv_tuple(data)
 
 
+def _wl_coord_dict(wl, *, units="μm"):
+    return {"wl": (("wl"), wl, {"long_name": "Wavelength", "units": units})}
+
+
 def _params_list_table(vmdes=None):
     """Form an entire MyST list-table.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,28 +20,26 @@ Analysis
 
    crt1d.diagnostics
 
-Setup
------
+Input data
+----------
 .. autosummary::
 
    crt1d.cases
-   crt1d.spectra
    crt1d.data
-
+   crt1d.spectra
 
 Leaf arrangement
 ----------------
 .. autosummary::
 
-   crt1d.leaf_area
    crt1d.leaf_angle
-
+   crt1d.leaf_area
 
 
 Other
 =====
 
-solvers
+Solvers
 -------
 
 :mod:`~crt1d.solvers` is mostly private, not intended to be used directly. Instead, the solvers
@@ -51,6 +49,14 @@ are used while attached to a :class:`crt1d.Model` instance.
 
    crt1d.solvers
    crt1d.solvers.common
+
+Internal tools
+--------------
+
+.. autosummary::
+
+   crt1d.utils
+   crt1d.variables
 
 
 AutoAPI

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,12 +90,9 @@ exclude_patterns = ["_build", "conf.py", "Thumbs.db", ".DS_Store", "../crt1d/*"]
 
 # -- Options for HTML output -------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-# html_theme = 'alabaster'
 # html_theme = "sphinx_rtd_theme"
-html_theme = "sphinx_book_theme"
+# html_theme = "sphinx_book_theme"
+html_theme = "furo"
 
 html_title = "crt1d"  # shown in top left, overriding "{project} {release} documentation"
 html_last_updated_fmt = "%Y-%m-%d"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,11 +42,22 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "xarray": ("https://xarray.pydata.org/en/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
 }
 
-# aliases? doesn't seem to work...
+# napoleon
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
+napoleon_preprocess_types = True
 napoleon_type_aliases = {
-    "xr.Dataset": ":class:`xarray.Dataset`",
+    "xr.Dataset": "xarray.Dataset",
+    # NumPy
+    "array_like": ":term:`array_like`",
+    "array-like": ":term:`array-like <array_like>`",
+    "scalar": ":term:`scalar`",
+    "array": ":term:`array`",
+    "np.ndarray": "numpy.ndarray",
+    "ndarray": "numpy.ndarray",
 }
 
 # include __init__() docstring content in autodocs for classes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,8 @@ import crt1d
 # -- Project information -----------------------------------------------------
 
 project = "crt1d"
-copyright = f"2020\u2013{datetime.datetime.now().year}"
-author = "Zachary Moon"
+author = "Z. Moon"
+copyright = f"2020\u2013{datetime.datetime.now().year}, {author}"
 
 # Get version from metadata
 release = get_distribution("crt1d").version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,11 +38,15 @@ extensions = [
     "myst_nb",
 ]
 
+
+# -- Extension settings ------------------------------------------------------
+
 # intersphinx
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "xarray": ("https://xarray.pydata.org/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
 }
 
 # napoleon
@@ -51,6 +55,7 @@ napoleon_numpy_docstring = True
 napoleon_preprocess_types = True
 napoleon_type_aliases = {
     "xr.Dataset": "xarray.Dataset",
+    "xr.DataArray": "xarray.DataArray",
     # NumPy
     "array_like": ":term:`array_like`",
     "array-like": ":term:`array-like <array_like>`",
@@ -58,6 +63,8 @@ napoleon_type_aliases = {
     "array": ":term:`array`",
     "np.ndarray": "numpy.ndarray",
     "ndarray": "numpy.ndarray",
+    # pandas
+    "pd.DataFrame": "pandas.DataFrame",
 }
 
 # include __init__() docstring content in autodocs for classes
@@ -74,6 +81,7 @@ autoapi_options = [
     "imported-members",
 ]
 autoapi_python_class_content = "both"  # include __init__ docstring as well as class
+autoapi_member_order = "groupwise"  # default is 'bysource'
 
 # bibtex
 bibtex_bibfiles = ["crt1d-refs.bib"]  # required in sphinxcontrib-bibtex v2

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -21,3 +21,4 @@ Data
    :maxdepth: 1
 
    examples/binning
+   examples/external-spectra

--- a/docs/examples/binning.md
+++ b/docs/examples/binning.md
@@ -53,6 +53,17 @@ ds2_l = crt.spectra.smear_ds(ds0_l, bins2)
 crt.spectra.plot_binned_ds(ds0_l, ds2_l, yname="rl")
 ```
 
+```{code-cell} ipython3
+bins3 = np.linspace(0.3, 2.6, 4)
+ds3_l = crt.spectra.smear_ds(ds0_l, bins3, method="tuv")
+crt.spectra.plot_binned_ds(ds0_l, ds3_l, yname="rl")
+```
+
+```{code-cell} ipython3
+ds3_l_2 = crt.spectra.smear_ds(ds0_l, bins3, method="avg_optical_prop")
+crt.spectra.plot_binned_ds(ds0_l, ds3_l_2, yname="rl")
+```
+
 ```{note}
 The bins do not have to be constant-width---variable grid will also work!
 ```

--- a/docs/examples/binning.md
+++ b/docs/examples/binning.md
@@ -20,6 +20,7 @@ Also, we can decrease canopy RT computational time by reducing spectral resoluti
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy import stats
 
 import crt1d as crt
 ```
@@ -33,63 +34,91 @@ ds0_l = crt.data.load_ideal_leaf().dropna(dim="wl")
 
 ## Different binnings
 
+### Solar
+
 Although the main purpose of the "smear" functions is to provide the ability to go to lower spectral resolution while conserving certain properties, they also work as interpolators when a higher resolution grid is used.
 
-```{code-cell} ipython3
-bins1 = np.linspace(0.3, 2.5, 20)
-ds1 = crt.spectra.smear_si(ds0, bins1)
-# ^ we use a special function to calculate smeared I by smearing SI
-crt.spectra.plot_binned_ds(ds0, ds1, yname="SI_df")
+```{note}
+The bins do not have to be equal-width---variable grid will also work!
 ```
 
 ```{code-cell} ipython3
-ds1_l = crt.spectra.smear_ds(ds0_l, bins1)
-crt.spectra.plot_binned_ds(ds0_l, ds1_l, yname="rl")
+ds0
 ```
 
 ```{code-cell} ipython3
-bins2 = np.linspace(0.3, 2.6, 200)
+binss = [
+    [0.3, 0.4, 0.5, 0.6, 0.7, 1.0, 1.5, 2.5],  # variable dx is supported
+    np.linspace(0.3, 2.5, 8),
+    np.linspace(0.3, 2.5, 21),
+    np.linspace(0.3, 2.5, 201),
+]
+
+fig, ax = plt.subplots(2, 2, figsize=(11, 7))
+
+for bins, ax in zip(binss, ax.flat):
+    # The spectral variables have coord `wl0`
+    crt.spectra.plot_binned_ds(ds0, crt.spectra.smear_ds(ds0, bins, xname="wl0"), yname="SI_df", xtight="bins", ax=ax)
+```
+
+```{warning}
+Irradiance (W m-2) should not be smeared directly (as we see below).
+Instead we use a special routine to calculate in-bin irradiance by smearing *spectral* irradiance (W m-2 μm-1).
+```
+
++++
+
+If we smear irradiance directly, the total irradiance is essentially proportional to the number of bins used. For equal-width bins, it turns out to be exactly proportional.
+
+```{code-cell} ipython3
+tot0 = ds0.I_dr.sum().values
+tot = []
+nbands = np.arange(1, 200, 10)
+for n in nbands:
+    tot.append(crt.spectra.smear_ds(ds0, np.linspace(0.3, 4.0, n)).I_dr.sum().values)
+
+res = stats.linregress(nbands, tot)
+
+fig, ax = plt.subplots()
+ax.plot(nbands, tot, ".-")
+ax.text(0.03, 0.96, f"Original total: {tot0:.4g}\nr$^2 = {res.rvalue**2:.3f}$", ha="left", va="top", transform=ax.transAxes)
+ax.set(xlabel="# of bands", ylabel="Total irradiance [W m-2]");
+```
+
+Instead, for computing irradiance in bins, {func}`crt1d.spectra.smear_si` can be used for convenience. It smears *spectral* irradiance and then multiplies by bin width to give irradiance.
+
++++
+
+### Leaf/soil optical properties
+
+Smearing leaf/soil optical properties directly comes with its own issues.
+
+Reflectance/transmittance are like albedo in that they depend on the incoming light as well. We can account for this by weighting with a light spectrum when averaging the optical property spectra.
+
+Below, we can see that when we compute the average reflectance, over certain regions this doesn't matter much (PAR/visible). In the NIR, however, there is a strong preference for smaller wavelengths, which overall weights leaf reflectance towards higher values.
+
+```{code-cell} ipython3
+ds0_l
+```
+
+```{code-cell} ipython3
+bins2 = np.linspace(0.3, 2.6, 21)
 ds2_l = crt.spectra.smear_ds(ds0_l, bins2)
 crt.spectra.plot_binned_ds(ds0_l, ds2_l, yname="rl")
 ```
 
+The influence of accounting for the incoming light spectrum is most apparent when the bins are large and few.
+
 ```{code-cell} ipython3
 bins3 = np.linspace(0.3, 2.6, 4)
-ds3_l = crt.spectra.smear_ds(ds0_l, bins3, method="tuv")
-crt.spectra.plot_binned_ds(ds0_l, ds3_l, yname="rl")
+
+fig, axs = plt.subplots(2, 1, figsize=(6, 6))
+
+for method, ax in zip(["tuv", "avg_optical_prop"], axs.flat):
+    crt.spectra.plot_binned_ds(ds0_l, crt.spectra.smear_ds(ds0_l, bins3, method=method), yname="rl", ax=ax)
 ```
 
-```{code-cell} ipython3
-ds3_l_2 = crt.spectra.smear_ds(ds0_l, bins3, method="avg_optical_prop")
-crt.spectra.plot_binned_ds(ds0_l, ds3_l_2, yname="rl")
-```
-
-```{note}
-The bins do not have to be constant-width---variable grid will also work!
-```
-
-## Planck function
-
-[Planck](https://en.wikipedia.org/wiki/Planck%27s_law) radiance can be used to weight values
-when smearing the spectra. This is important for albedo, for example, because albedo in some waveband (such as visible or shortwave) depends on both the albedo spectrum and the spectrum of the illuminating light.
-
-```{code-cell} ipython3
-wl_um = np.linspace(0.3, 2.6, 200)
-fig, ax = plt.subplots()
-for T_K in [4000, 5000, 5800, 6000]:
-    ax.plot(wl_um, crt.spectra.l_wl_planck(T_K, wl_um), label=T_K)
-ax.set(
-    xlabel=r"Wavelength $\lambda$ [μm]",
-    ylabel=r"Spectral radiance $L(\lambda)$ [W sr$^{-1}$ m$^{-2}$ m$^{-1}$]",
-)
-ax.legend(title="Blackbody temperature (K)")
-```
-
-## Optical properties
-
-Smearing optical properties as shown above is a bit unfair(?). As mentioned in the previous section, reflectance/transmittance are like albedo in that they depend on the incoming light as well. We can account for this by weighting with a light spectrum when averaging the optical property spectra.
-
-Below, we can see that when we compute the average reflectance, over certain regions this doesn't matter much (PAR/visible). In the NIR, however, there is a strong preference for smaller wavelengths, which overall weights leaf reflectance towards higher values.
+## Average optical properties
 
 ```{code-cell} ipython3
 # On the original leaf reflectance spectrum
@@ -107,9 +136,10 @@ for bounds in boundss:
 
 ```{code-cell} ipython3
 # On the smeared/binned leaf reflectance spectrum
+ds2 = crt.spectra.smear_ds(ds0, bins2)
 data = (
-    ds1.sel(wl=ds1_l.wl.values, method="nearest").I_dr +
-    ds1.sel(wl=ds1_l.wl.values, method="nearest").I_df
+    ds2.sel(wl=ds2_l.wl.values, method="nearest").I_dr +
+    ds2.sel(wl=ds2_l.wl.values, method="nearest").I_df
 )
 lights = ["planck", "uniform", data]
 
@@ -117,7 +147,7 @@ for bounds in boundss:
     print(bounds)
     for light in lights:
         ybar = crt.spectra.avg_optical_prop(
-            ds1_l.rl, bounds, xe=ds1_l.wle, light=light
+            ds2_l.rl, bounds, xe=ds2_l.wle, light=light
         )
         if isinstance(light, str):
             print(f" {light}: {ybar:.4g}")
@@ -126,3 +156,22 @@ for bounds in boundss:
 ```
 
 👆 Notice that over the whole spectrum, the values for 'uniform' and 'planck' are very similar to the calculations on the pre-smeared spectrum.
+
++++
+
+## Planck function
+
+[Planck](https://en.wikipedia.org/wiki/Planck%27s_law) radiance is one of the `light` options can be used to weight values
+when smearing the spectra with the `avg_optical_prop` option. This is important for albedo, for example, because albedo in some waveband (such as visible or shortwave) depends on both the albedo spectrum and the spectrum of the illuminating light.
+
+```{code-cell} ipython3
+wl_um = np.linspace(0.3, 2.6, 200)
+fig, ax = plt.subplots()
+for T_K in [4000, 5000, 5800, 6000]:
+    ax.plot(wl_um, crt.spectra.l_wl_planck(T_K, wl_um), label=T_K)
+ax.set(
+    xlabel=r"Wavelength $\lambda$ [μm]",
+    ylabel=r"Spectral radiance $L(\lambda)$ [W sr$^{-1}$ m$^{-2}$ m$^{-1}$]",
+)
+ax.legend(title="Blackbody temperature (K)");
+```

--- a/docs/examples/binning.md
+++ b/docs/examples/binning.md
@@ -91,12 +91,6 @@ Instead, for computing irradiance in bins, {func}`crt1d.spectra.smear_si` can be
 
 ### Leaf/soil optical properties
 
-Smearing leaf/soil optical properties directly comes with its own issues.
-
-Reflectance/transmittance are like albedo in that they depend on the incoming light as well. We can account for this by weighting with a light spectrum when averaging the optical property spectra.
-
-Below, we can see that when we compute the average reflectance, over certain regions this doesn't matter much (PAR/visible). In the NIR, however, there is a strong preference for smaller wavelengths, which overall weights leaf reflectance towards higher values.
-
 ```{code-cell} ipython3
 ds0_l
 ```
@@ -106,6 +100,28 @@ bins2 = np.linspace(0.3, 2.6, 21)
 ds2_l = crt.spectra.smear(ds0_l, bins2)
 crt.spectra.plot_binned_ds(ds0_l, ds2_l, yname="rl")
 ```
+
+Function {func}`crt1d.spectra.smear` can be applied to array-like, {class}`xarray.DataArray`, or {class}`xarray.Dataset`.
+
+```{code-cell} ipython3
+# `x` array must be provided if passing array
+crt.spectra.smear(ds2_l.rl.values, bins2, x=ds2_l.wl)
+```
+
+```{code-cell} ipython3
+# `x` assumed to be the variable with `name` `'wl'`
+crt.spectra.smear(ds2_l.rl, bins2)
+```
+
+```{code-cell} ipython3
+crt.spectra.smear(ds2_l, bins2)
+```
+
+```{warning}
+Smearing leaf/soil optical properties directly causes issues as well, though more subtle than for irradiance.
+```
+
+Reflectance/transmittance are like albedo in that they depend on the incoming light as well. We can account for this by weighting with a light spectrum when averaging the optical property spectra.
 
 The influence of accounting for the incoming light spectrum is most apparent when the bins are large and few.
 
@@ -119,6 +135,10 @@ for method, ax in zip(["tuv", "avg_optical_prop"], axs.flat):
 ```
 
 ## Average optical properties
+
+Below, we can see that when we compute the average reflectance, over certain regions the above doesn't matter much (PAR/visible). In the NIR, however, there is a strong preference for smaller wavelengths, which overall weights leaf reflectance towards higher values.
+
+In the below, `'unifrom'` corresponds to standard smearing, with no solar weighting.
 
 ```{code-cell} ipython3
 # On the original leaf reflectance spectrum
@@ -135,7 +155,7 @@ for bounds in boundss:
 ```
 
 ```{code-cell} ipython3
-# On the smeared/binned leaf reflectance spectrum
+# On a smeared/binned leaf reflectance spectrum
 ds2 = crt.spectra.smear(ds0, bins2)
 data = (
     ds2.sel(wl=ds2_l.wl.values, method="nearest").I_dr +
@@ -155,7 +175,7 @@ for bounds in boundss:
             print(f" data: {ybar:.4g}")
 ```
 
-👆 Notice that over the whole spectrum, the values for 'uniform' and 'planck' are very similar to the calculations on the pre-smeared spectrum.
+👆 Notice that the values for `'uniform'` and `'planck'` are similar (though not identical) to the calculations on the pre-smeared spectrum.
 
 +++
 
@@ -174,18 +194,4 @@ ax.set(
     ylabel=r"Spectral radiance $L(\lambda)$ [W sr$^{-1}$ m$^{-2}$ m$^{-1}$]",
 )
 ax.legend(title="Blackbody temperature (K)");
-```
-
-Function {func}`crt1d.spectra.smear` can be applied to array-like, {class}`xarray.DataArray`, or {class}`xarray.Dataset`.
-
-```{code-cell} ipython3
-crt.spectra.smear(ds2_l.rl.values, bins2, x=ds2_l.wl)
-```
-
-```{code-cell} ipython3
-crt.spectra.smear(ds2_l.rl, bins2)
-```
-
-```{code-cell} ipython3
-crt.spectra.smear(ds2_l, bins2)
 ```

--- a/docs/examples/binning.md
+++ b/docs/examples/binning.md
@@ -73,3 +73,49 @@ ax.set(
 )
 ax.legend(title="Blackbody temperature (K)")
 ```
+
+## Optical properties
+
+Smearing optical properties as shown above is a bit unfair(?). As mentioned in the previous section, reflectance/transmittance are like albedo in that they depend on the incoming light as well. We can account for this by weighting with a light spectrum when averaging the optical property spectra.
+
+Below, we can see that when we compute the average reflectance, over certain regions this doesn't matter much (PAR/visible). In the NIR, however, there is a strong preference for smaller wavelengths, which overall weights leaf reflectance towards higher values.
+
+```{code-cell} ipython3
+# On the original leaf reflectance spectrum
+boundss = [(0.4, 0.7), (0.7, 1.0), (1.0, 2.5), (0.3, 2.5)]
+lights = ["planck", "uniform"]
+
+for bounds in boundss:
+    print(bounds)
+    for light in lights:
+        ybar = crt.spectra.avg_optical_prop(
+            ds0_l.rl, bounds, x=ds0_l.wl, light=light
+        )
+        print(f" {light}: {ybar:.4g}")
+```
+
+```{code-cell} ipython3
+# On the smeared/binned leaf reflectance spectrum
+data = (
+    ds1.sel(wl=ds1_l.wl.values, method="nearest").I_dr +
+    ds1.sel(wl=ds1_l.wl.values, method="nearest").I_df
+)
+lights = ["planck", "uniform", data]
+
+for bounds in boundss:
+    print(bounds)
+    for light in lights:
+        ybar = crt.spectra.avg_optical_prop(
+            ds1_l.rl, bounds, xe=ds1_l.wle, light=light
+        )
+        if isinstance(light, str):
+            print(f" {light}: {ybar:.4g}")
+        else:
+            print(f" data: {ybar:.4g}")
+```
+
+👆 Notice that over the whole spectrum, the values for 'uniform' and 'planck' are very similar to the calculations on the pre-smeared spectrum.
+
+```{code-cell} ipython3
+
+```

--- a/docs/examples/binning.md
+++ b/docs/examples/binning.md
@@ -115,7 +115,3 @@ for bounds in boundss:
 ```
 
 👆 Notice that over the whole spectrum, the values for 'uniform' and 'planck' are very similar to the calculations on the pre-smeared spectrum.
-
-```{code-cell} ipython3
-
-```

--- a/docs/examples/binning.md
+++ b/docs/examples/binning.md
@@ -1,23 +1,24 @@
 ---
-kernelspec:
-  display_name: Python 3
-  name: python3
 jupytext:
-  cell_metadata_filter: -all
-  formats: md:myst
-  main_language: python
   text_representation:
     extension: .md
     format_name: myst
     format_version: 0.12
-    jupytext_version: 1.6.0
+    jupytext_version: 1.9.1
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
 ---
 
-# Demonstrate binning functionality
+# Binning spectra
 
-In module {mod}`crt1d.spectra`.
+Module {mod}`crt1d.spectra` provides some tools for working with spectra.
+By binning or smearing spectra, we can use spectra together that were originally on different grids.
+Also, we can decrease canopy RT computational time by reducing spectral resolution.
 
-```{code-cell}
+```{code-cell} ipython3
+import matplotlib.pyplot as plt
 import numpy as np
 
 import crt1d as crt
@@ -25,29 +26,50 @@ import crt1d as crt
 
 ## Load included spectra
 
-```{code-cell}
+```{code-cell} ipython3
 ds0 = crt.data.load_default_sp2()
 ds0_l = crt.data.load_ideal_leaf().dropna(dim="wl")
 ```
 
-## Show different binnings
+## Different binnings
 
-```{code-cell}
+Although the main purpose of the "smear" functions is to provide the ability to go to lower spectral resolution while conserving certain properties, they also work as interpolators when a higher resolution grid is used.
+
+```{code-cell} ipython3
 bins1 = np.linspace(0.3, 2.5, 20)
 ds1 = crt.spectra.smear_si(ds0, bins1)
 # ^ we use a special function to calculate smeared I by smearing SI
 crt.spectra.plot_binned_ds(ds0, ds1, yname="SI_df")
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 ds1_l = crt.spectra.smear_ds(ds0_l, bins1)
 crt.spectra.plot_binned_ds(ds0_l, ds1_l, yname="rl")
 ```
 
-```{code-cell}
-bins2 = np.linspace(0.3, 2.6, 50)
+```{code-cell} ipython3
+bins2 = np.linspace(0.3, 2.6, 200)
 ds2_l = crt.spectra.smear_ds(ds0_l, bins2)
 crt.spectra.plot_binned_ds(ds0_l, ds2_l, yname="rl")
 ```
 
-Note that the bins do not have to be constant-width---variable grid will also work!
+```{note}
+The bins do not have to be constant-width---variable grid will also work!
+```
+
+## Planck function
+
+[Planck](https://en.wikipedia.org/wiki/Planck%27s_law) radiance can be used to weight values
+when smearing the spectra. This is important for albedo, for example, because albedo in some waveband (such as visible or shortwave) depends on both the albedo spectrum and the spectrum of the illuminating light.
+
+```{code-cell} ipython3
+wl_um = np.linspace(0.3, 2.6, 200)
+fig, ax = plt.subplots()
+for T_K in [4000, 5000, 5800, 6000]:
+    ax.plot(wl_um, crt.spectra.l_wl_planck(T_K, wl_um), label=T_K)
+ax.set(
+    xlabel=r"Wavelength $\lambda$ [μm]",
+    ylabel=r"Spectral radiance $L(\lambda)$ [W sr$^{-1}$ m$^{-2}$ m$^{-1}$]",
+)
+ax.legend(title="Blackbody temperature (K)")
+```

--- a/docs/examples/binning.md
+++ b/docs/examples/binning.md
@@ -58,7 +58,7 @@ fig, ax = plt.subplots(2, 2, figsize=(11, 7))
 
 for bins, ax in zip(binss, ax.flat):
     # The spectral variables have coord `wl0`
-    crt.spectra.plot_binned_ds(ds0, crt.spectra.smear_ds(ds0, bins, xname="wl0"), yname="SI_df", xtight="bins", ax=ax)
+    crt.spectra.plot_binned_ds(ds0, crt.spectra.smear(ds0, bins, x="wl0"), yname="SI_df", xtight="bins", ax=ax)
 ```
 
 ```{warning}
@@ -75,7 +75,7 @@ tot0 = ds0.I_dr.sum().values
 tot = []
 nbands = np.arange(1, 200, 10)
 for n in nbands:
-    tot.append(crt.spectra.smear_ds(ds0, np.linspace(0.3, 4.0, n)).I_dr.sum().values)
+    tot.append(crt.spectra.smear(ds0, np.linspace(0.3, 4.0, n)).I_dr.sum().values)
 
 res = stats.linregress(nbands, tot)
 
@@ -103,7 +103,7 @@ ds0_l
 
 ```{code-cell} ipython3
 bins2 = np.linspace(0.3, 2.6, 21)
-ds2_l = crt.spectra.smear_ds(ds0_l, bins2)
+ds2_l = crt.spectra.smear(ds0_l, bins2)
 crt.spectra.plot_binned_ds(ds0_l, ds2_l, yname="rl")
 ```
 
@@ -115,7 +115,7 @@ bins3 = np.linspace(0.3, 2.6, 4)
 fig, axs = plt.subplots(2, 1, figsize=(6, 6))
 
 for method, ax in zip(["tuv", "avg_optical_prop"], axs.flat):
-    crt.spectra.plot_binned_ds(ds0_l, crt.spectra.smear_ds(ds0_l, bins3, method=method), yname="rl", ax=ax)
+    crt.spectra.plot_binned_ds(ds0_l, crt.spectra.smear(ds0_l, bins3, method=method), yname="rl", ax=ax)
 ```
 
 ## Average optical properties
@@ -136,7 +136,7 @@ for bounds in boundss:
 
 ```{code-cell} ipython3
 # On the smeared/binned leaf reflectance spectrum
-ds2 = crt.spectra.smear_ds(ds0, bins2)
+ds2 = crt.spectra.smear(ds0, bins2)
 data = (
     ds2.sel(wl=ds2_l.wl.values, method="nearest").I_dr +
     ds2.sel(wl=ds2_l.wl.values, method="nearest").I_df
@@ -174,4 +174,18 @@ ax.set(
     ylabel=r"Spectral radiance $L(\lambda)$ [W sr$^{-1}$ m$^{-2}$ m$^{-1}$]",
 )
 ax.legend(title="Blackbody temperature (K)");
+```
+
+Function {func}`crt1d.spectra.smear` can be applied to array-like, {class}`xarray.DataArray`, or {class}`xarray.Dataset`.
+
+```{code-cell} ipython3
+crt.spectra.smear(ds2_l.rl.values, bins2, x=ds2_l.wl)
+```
+
+```{code-cell} ipython3
+crt.spectra.smear(ds2_l.rl, bins2)
+```
+
+```{code-cell} ipython3
+crt.spectra.smear(ds2_l, bins2)
 ```

--- a/docs/examples/external-spectra.md
+++ b/docs/examples/external-spectra.md
@@ -110,3 +110,17 @@ plot(ds)
 ```{code-cell} ipython3
 # TODO: others
 ```
+
+## PROSPECT-5
+
+```{code-cell} ipython3
+ds = crt.data.leaf_ps5()
+
+fig, ax = plt.subplots()
+
+ds.rl.plot(ax=ax, label="reflectance")
+ds.tl.plot(ax=ax, label="transmittance")
+
+ax.set(ylabel="")
+ax.legend(title="Leaf element")
+```

--- a/docs/examples/external-spectra.md
+++ b/docs/examples/external-spectra.md
@@ -52,11 +52,11 @@ ds.SI_dr.plot(ax=ax, label="direct")
 ds.SI_df.plot(ax=ax, label="diffuse")
 
 ax.set(ylabel=f"Spectral irradiance [{ds.SI_dr.units}]")
-ax.legend()
+ax.legend();
 ```
 
 ```{code-cell} ipython3
-ds.plot.scatter(x="SI_dr", y="SI_df")
+ds.plot.scatter(x="SI_dr", y="SI_df");
 ```
 
 ### Variations
@@ -113,6 +113,8 @@ plot(ds)
 
 ## PROSPECT-5
 
+{func}`crt1d.data.leaf_ps5` runs PROSPECT-5 (via [Python PROSAIL](https://github.com/jgomezdans/prosail)) and saves the results to an {class}`xarray.Dataset`.
+
 ```{code-cell} ipython3
 ds = crt.data.leaf_ps5()
 ds
@@ -125,5 +127,5 @@ ds.rl.plot(ax=ax, label="reflectance")
 ds.tl.plot(ax=ax, label="transmittance")
 
 ax.set(ylabel="")
-ax.legend(title="Leaf element")
+ax.legend(title="Leaf element");
 ```

--- a/docs/examples/external-spectra.md
+++ b/docs/examples/external-spectra.md
@@ -1,0 +1,112 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.12
+    jupytext_version: 1.9.1
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# External spectra sources
+
+`crt1d` comes with some functions that facilitate easy generation of leaf optical property and top-of-canopy irradiance spectra using external programs. These can be found in module {mod}`crt1d.data`.
+
+```{code-cell} ipython3
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+import crt1d as crt
+```
+
+## SPCTRAL2
+
+{func}`crt1d.data.solar_sp2` runs SPCTRAL2 (via [SolarUtils](https://github.com/SunPower/SolarUtils)) and saves the results to an {class}`xarray.Dataset`.
+
++++
+
+### Example
+
+[Walker Building](https://goo.gl/maps/gXy477ZtfF2cmwB59) in the summer around local solar noon.
+
+```{code-cell} ipython3
+lat = 40.793275995962944
+lon = -77.86686570952304
+dt0 = pd.Timestamp("2021/07/01 13:00")
+utcoffset = -4  # EDT
+
+ds = crt.data.solar_sp2(dt0, lat, lon, utcoffset=utcoffset)
+ds
+```
+
+```{code-cell} ipython3
+fig, ax = plt.subplots()
+
+ds.SI_dr.plot(ax=ax, label="direct")
+ds.SI_df.plot(ax=ax, label="diffuse")
+
+ax.set(ylabel=f"Spectral irradiance [{ds.SI_dr.units}]")
+ax.legend()
+```
+
+```{code-cell} ipython3
+ds.plot.scatter(x="SI_dr", y="SI_df")
+```
+
+### Variations
+
+#### Time of day
+
+```{code-cell} ipython3
+dts = pd.date_range("2021/07/01 10:00", "2021/07/01 20:00", freq="15min")
+
+ds = xr.concat(
+    [crt.data.solar_sp2(dt, lat, lon, utcoffset=utcoffset) for dt in dts],
+    dim="time"
+)
+
+def plot(ds, x=None):  
+    if x is None:
+        x = list(ds.dims)[0]
+
+    fig, axs = plt.subplots(2, 2, figsize=(9, 6))
+    ax1, ax2, ax3, ax4 = axs.flat
+
+    ds.SI_dr.plot(x=x, ax=ax1)
+    ds.SI_df.plot(x=x, ax=ax2)
+
+    norm = mpl.colors.LogNorm(vmin=1e-10)
+    (ds.SI_dr / ds.SI_dr.isel({x: 0})).plot(x=x, ax=ax3, norm=norm)
+    (ds.SI_df / ds.SI_df.isel({x: 0})).plot(x=x, ax=ax4, norm=norm)
+
+    fig.tight_layout()
+
+plot(ds)
+```
+
+👆 The second row shows how the spectrum shape changes since the first time shown. It seems that, for the most part, the spectrum shape doesn't change much with time of day on a given day in this model (except around 2.7 μm).
+
++++
+
+#### Parameters
+
+```{code-cell} ipython3
+watvaps = np.linspace(0.1, 10., 100)
+
+ds = xr.concat(
+    [crt.data.solar_sp2(dt0, lat, lon, utcoffset=utcoffset, watvap=watvap) for watvap in watvaps],
+    dim="watvap"
+)
+
+plot(ds)
+```
+
+```{code-cell} ipython3
+# TODO: others
+```

--- a/docs/examples/external-spectra.md
+++ b/docs/examples/external-spectra.md
@@ -115,7 +115,10 @@ plot(ds)
 
 ```{code-cell} ipython3
 ds = crt.data.leaf_ps5()
+ds
+```
 
+```{code-cell} ipython3
 fig, ax = plt.subplots()
 
 ds.rl.plot(ax=ax, label="reflectance")

--- a/docs/examples/test_schemes_plot.md
+++ b/docs/examples/test_schemes_plot.md
@@ -17,8 +17,8 @@ We test the following:
 
 * running the model with default case
 * plot methods for {class}`~crt1d.Model` class
-* :class:`xarray.Dataset` output
-* plots for output `xarray.Dataset`s
+* {class}`xarray.Dataset` output
+* plots for output {class}`xarray.Dataset`s
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt

--- a/docs/examples/test_schemes_plot.md
+++ b/docs/examples/test_schemes_plot.md
@@ -1,16 +1,14 @@
 ---
-kernelspec:
-  display_name: Python 3
-  name: python3
 jupytext:
-  cell_metadata_filter: -all
-  formats: md:myst
-  main_language: python
   text_representation:
     extension: .md
     format_name: myst
     format_version: 0.12
-    jupytext_version: 1.6.0
+    jupytext_version: 1.9.1
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
 ---
 
 # Run each scheme
@@ -19,26 +17,22 @@ We test the following:
 
 * running the model with default case
 * plot methods for {class}`~crt1d.Model` class
-* output xr
-* plots for {class}`~crt1d.Model` class
-* plots for output xr
+* :class:`xarray.Dataset` output
+* plots for output `xarray.Dataset`s
 
-```{code-cell}
+```{code-cell} ipython3
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import xarray as xr
 
 import crt1d as crt
-
-#%matplotlib widget  # currently doesn't work (though the widget buttons show up)
-%matplotlib inline
 ```
 
 ## Run (just once)
 Run the default case (which is loaded automatically when model object is created).
 
-```{code-cell}
+```{code-cell} ipython3
 scheme_names = list(crt.solvers.AVAILABLE_SCHEMES)
 
 ms = []
@@ -55,45 +49,45 @@ dsets = [m.to_xr() for m in ms]
 
 Leaf area profile and leaf angle dist, using the plotting methods attached to the {class}`~crt1d.Model` instance.
 
-```{code-cell}
+```{code-cell} ipython3
 ms[0].plot_canopy()
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 ms[0].plot_leafsoil_spectra()
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 ms[0].plot_toc_spectra()
 ```
 
 ## Plots of results
 
-```{code-cell}
+```{code-cell} ipython3
 crt.diagnostics.plot_compare_band(dsets, band_name="PAR")
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 crt.diagnostics.plot_compare_band(dsets, band_name="solar")
 ```
 
 ### Other diagnostic tools
 
-```{code-cell}
-crt.diagnostics.df_E_balance(dsets).astype(float).round(3)
+```{code-cell} ipython3
+crt.diagnostics.compare_ebal(dsets).astype(float).round(3)
 ```
 
 ## Datasets and their variables
 
-```{code-cell}
+```{code-cell} ipython3
 dsets[0]
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 dsets[0]["zm"]
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 # some have extra outputs
 ms[scheme_names.index("zq")].out_extra
 ```

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   #
   # for docs work
   - jupytext
-  - notebook
+  - jupyterlab>=3
   - sphinx
   #
   - pip  # otherwise conda nags

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ data =
   SolarUtils  # run SPCTRAL2 to get more solar spectra
 docs =
   %(data)s
+  furo
+  myst-nb
   sphinx
-  sphinx-book-theme
   sphinx-autoapi
   sphinxcontrib-bibtex
-  myst-nb


### PR DESCRIPTION
Main addition: `avg_optical_prop` and `smear_avg_optical_prop`, functions that incorporate the light spectrum when calculating the integrated average of a quantity like leaf reflectance. Planck radiance is one of the weighting options.

Also
* Furo theme
* various improvements to docstrings
* figured out how to do the Napoleon type aliases properly by looking at xarray's `conf.py`
* some renaming (mainly making `_...` protected to avoid inclusion in API doc) and moving around of things
* implement `leaf_ps5`
* new example nb that demos the external spectra sources
* implement new `smear` fn that works for array-like or xarray